### PR TITLE
Add missing critical-section implementation flag

### DIFF
--- a/neotron-bmc-pico/Cargo.toml
+++ b/neotron-bmc-pico/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 version = "0.4.0"
 
 [dependencies]
-cortex-m = { version = "0.7.5", features = ["inline-asm"] }
+cortex-m = { version = "0.7.5", features = ["inline-asm", "critical-section-single-core"] }
 cortex-m-rtic = "1.0"
 debouncr = "0.2"
 defmt = "0.3"


### PR DESCRIPTION
Due to [this](https://ferrous-systems.com/blog/defmt-rtt-linker-error/).