### PR TITLE
Force-reset the SPI block when you reset the host.

### DIFF
--- a/neotron-bmc-pico/src/spi.rs
+++ b/neotron-bmc-pico/src/spi.rs
@@ -6,6 +6,7 @@
 use stm32f0xx_hal::{pac, prelude::*, rcc::Rcc};
 
 pub struct SpiPeripheral<const RXC: usize, const TXC: usize> {
+	/// Our PAC object for register access
 	dev: pac::SPI1,
 	/// A space for bytes received from the host
 	rx_buffer: [u8; RXC],
@@ -23,6 +24,9 @@ pub struct SpiPeripheral<const RXC: usize, const TXC: usize> {
 }
 
 impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
+	const MODE: embedded_hal::spi::Mode = embedded_hal::spi::MODE_0;
+
+	/// Construct a new driver
 	pub fn new<SCKPIN, MISOPIN, MOSIPIN>(
 		dev: pac::SPI1,
 		pins: (SCKPIN, MISOPIN, MOSIPIN),
@@ -35,24 +39,53 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 	{
 		defmt::info!("pclk = {}", rcc.clocks.pclk().0,);
 
-		let mode = embedded_hal::spi::MODE_0;
-
 		// Set SPI up in Controller mode. This will cause the HAL to enable the clocks and power to the IP block.
 		// It also checks the pins are OK.
-		let spi_controller = stm32f0xx_hal::spi::Spi::spi1(dev, pins, mode, 8_000_000u32.hz(), rcc);
+		let spi_controller =
+			stm32f0xx_hal::spi::Spi::spi1(dev, pins, Self::MODE, 8_000_000u32.hz(), rcc);
 		// Now disassemble the driver so we can set it into Controller mode instead
 		let (dev, _pins) = spi_controller.release();
 
+		let mut spi = SpiPeripheral {
+			dev,
+			rx_buffer: [0u8; RXC],
+			rx_idx: 0,
+			tx_buffer: [0u8; TXC],
+			tx_idx: 0,
+			tx_ready: 0,
+			is_done: false,
+		};
+
+		spi.config(Self::MODE);
+
+		// Empty the receive register
+		while spi.has_rx_data() {
+			let _ = spi.raw_read();
+		}
+
+		// Enable the SPI device
+		spi.stop();
+		spi.dev.cr1.write(|w| {
+			// Enable the peripheral
+			w.spe().enabled();
+			w
+		});
+
+		spi
+	}
+
+	/// Set up the registers
+	fn config(&mut self, mode: embedded_hal::spi::Mode) {
 		// We are following DM00043574, Section 30.5.1 Configuration of SPI
 
 		// 1. Disable SPI
-		dev.cr1.modify(|_r, w| {
+		self.dev.cr1.modify(|_r, w| {
 			w.spe().disabled();
 			w
 		});
 
 		// 2. Write to the SPI_CR1 register. Apologies for the outdated terminology.
-		dev.cr1.write(|w| {
+		self.dev.cr1.write(|w| {
 			// 2a. Configure the serial clock baud rate (ignored in peripheral mode)
 			w.br().div2();
 			// 2b. Configure the CPHA and CPOL bits.
@@ -83,7 +116,7 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 		});
 
 		// 3. Write to SPI_CR2 register
-		dev.cr2.write(|w| {
+		self.dev.cr2.write(|w| {
 			// 3a. Configure the DS[3:0] bits to select the data length for the transfer (0b111 = 8-bit words).
 			unsafe { w.ds().bits(0b111) };
 			// 3b. Disable hard-output on the CS pin (ignored in Master mode)
@@ -109,31 +142,6 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 		// 4. SPI_CRCPR - not required
 
 		// 5. DMA registers - not required
-
-		let mut spi = SpiPeripheral {
-			dev,
-			rx_buffer: [0u8; RXC],
-			rx_idx: 0,
-			tx_buffer: [0u8; TXC],
-			tx_idx: 0,
-			tx_ready: 0,
-			is_done: false,
-		};
-
-		// Empty the receive register
-		while spi.has_rx_data() {
-			let _ = spi.raw_read();
-		}
-
-		// Enable the SPI device
-		spi.stop();
-		spi.dev.cr1.write(|w| {
-			// Enable the peripheral
-			w.spe().enabled();
-			w
-		});
-
-		spi
 	}
 
 	/// Enable the SPI peripheral (i.e. when CS goes low)
@@ -156,6 +164,41 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 	pub fn stop(&mut self) {
 		self.dev.cr1.modify(|_r, w| {
 			w.ssi().slave_not_selected();
+			w
+		});
+	}
+
+	/// Fully reset the SPI peripheral
+	pub fn reset(&mut self, _rcc: &mut stm32f0xx_hal::rcc::Rcc) {
+		self.dev.cr1.write(|w| {
+			// Disable the peripheral
+			w.spe().disabled();
+			w
+		});
+
+		// Reset the IP manually. This is OK as we have exclusive access to the
+		// RCC peripheral. But sadly the RCC peripheral doesn't let us reset
+		// anything (it assumes it can handle it all internally).
+		let reset_reg = 0x4002_100C as *mut u32;
+		let spi1_bit = 1 << 12;
+		unsafe {
+			*reset_reg |= spi1_bit;
+			*reset_reg &= !(spi1_bit);
+		}
+
+		// Reconfigure
+		self.config(Self::MODE);
+
+		// Empty the receive register
+		while self.has_rx_data() {
+			let _ = self.raw_read();
+		}
+
+		// Enable the SPI device and leave it idle
+		self.stop();
+		self.dev.cr1.write(|w| {
+			// Enable the peripheral
+			w.spe().enabled();
 			w
 		});
 	}


### PR DESCRIPTION
This is because the host might be mid-SPI-byte, and we don't want to leave any bits in the receive register. The SPI block itself won't let you clear them, so we just reset it.

Sadly the Rcc driver in the HAL has no useful methods, so we ensure we have the object (for exclusive access) then do some raw pointer writes.