### PR TITLE
Add interrupt support

### DIFF
--- a/neotron-bmc-pico/src/main.rs
+++ b/neotron-bmc-pico/src/main.rs
@@ -809,11 +809,4 @@ where
 	// defmt::debug!("Sent {:?}", rsp);
 }
 
-// TODO: Pins we haven't used yet
-// SPI pins
-// spi_clk: gpioa.pa5.into_alternate_af0(cs),
-// spi_cipo: gpioa.pa6.into_alternate_af0(cs),
-// spi_copi: gpioa.pa7.into_alternate_af0(cs),
-// I²C pins
-// i2c_scl: gpiob.pb6.into_alternate_af4(cs),
-// i2c_sda: gpiob.pb7.into_alternate_af4(cs),
+// End of file

--- a/neotron-bmc-pico/src/spi.rs
+++ b/neotron-bmc-pico/src/spi.rs
@@ -67,11 +67,6 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 
 		// Enable the SPI device
 		spi.stop();
-		spi.dev.cr1.write(|w| {
-			// Enable the peripheral
-			w.spe().enabled();
-			w
-		});
 
 		spi
 	}
@@ -186,6 +181,9 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 	}
 
 	/// Fully reset the SPI peripheral
+	///
+	/// This is like calling [`Self::stop()`] but it reboots the IP block to clear any
+	/// partial words from the RX FIFO.
 	pub fn reset(&mut self, _rcc: &mut stm32f0xx_hal::rcc::Rcc) {
 		self.dev.cr1.write(|w| {
 			// Disable the peripheral
@@ -211,13 +209,8 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 			let _ = self.raw_read();
 		}
 
-		// Enable the SPI device and leave it idle
+		// Leave the SPI device turned off
 		self.stop();
-		self.dev.cr1.write(|w| {
-			// Enable the peripheral
-			w.spe().enabled();
-			w
-		});
 	}
 
 	/// Does the RX FIFO have any data in it?

--- a/neotron-bmc-pico/src/spi.rs
+++ b/neotron-bmc-pico/src/spi.rs
@@ -171,6 +171,7 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 		// Tell the SPI engine it has a chip-select
 		self.dev.cr1.modify(|_r, w| {
 			w.ssi().slave_selected();
+			w.spe().enabled();
 			w
 		});
 	}
@@ -179,6 +180,7 @@ impl<const RXC: usize, const TXC: usize> SpiPeripheral<RXC, TXC> {
 	pub fn stop(&mut self) {
 		self.dev.cr1.modify(|_r, w| {
 			w.ssi().slave_not_selected();
+			w.spe().disabled();
 			w
 		});
 	}


### PR DESCRIPTION
Sets the IRQ output high when the host is powered on, and there's something in the PS/2 buffer.

Also fixes an issue where CIPO was stuck low, stopping you from reading from any other device on the bus.