### PR TITLE
Handle alt commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased Changes
 
-* None
+* Handle 'Alt' reads and writes.
 
 ## v0.5.1
 

--- a/neotron-bmc-commands/README.md
+++ b/neotron-bmc-commands/README.md
@@ -211,16 +211,20 @@ TODO
 
 ### Address 0x70 - Speaker Tone Duration
 
-TODO
+Sets the duration of the tone to be played, and starts the tone playing. You
+should set the other three registers (if required) before setting this register.
+
+There is no way to know when the tone is ended; the host should keep track of
+the duration it set and wait the appropriate period of time.
 
 ### Address 0x71 - Speaker Tone Period (High)
 
-TODO
+Sets the upper 8 bits of the tone period. This is the inverse of frequency, in 48 kHz units.
 
 ### Address 0x72 - Speaker Tone Period (Low)
 
-TODO
+Sets the lower 8 bits of the tone period. See *Speaker Tone Period (High)* for details.
 
 ### Address 0x73 - Speaker Tone Duty Cycle
 
-TODO
+Sets the duty-cycle of the speaker tone. A value of 127 is 50:50 (a square wave).

--- a/neotron-bmc-protocol/src/lib.rs
+++ b/neotron-bmc-protocol/src/lib.rs
@@ -134,6 +134,19 @@ pub struct ProtocolVersion {
 // Impls
 // ============================================================================
 
+impl RequestType {
+	/// Converts an 'alt' command into a regular command.
+	///
+	/// Once you've checked for duplicates, you don't care which you've got.
+	pub fn flatten(self) -> Self {
+		match self {
+			RequestType::LongWrite | RequestType::LongWriteAlt => RequestType::LongWrite,
+			RequestType::ShortWrite | RequestType::ShortWriteAlt => RequestType::ShortWrite,
+			RequestType::Read | RequestType::ReadAlt => RequestType::Read,
+		}
+	}
+}
+
 impl Request {
 	/// Make a new Read Request, requesting the given register and number of
 	/// bytes.


### PR DESCRIPTION
A Read and a ReadAlt should be treated the same, and now are. The alt only exists so you don't think a repeated read is a duplicate read. But after duplicates have been checked, we don't care.

Also updates the API docs for the speaker registers.